### PR TITLE
xcodebuild default target

### DIFF
--- a/lib/choctop.rb
+++ b/lib/choctop.rb
@@ -55,11 +55,8 @@ module ChocTop
   
     # The name of the target in Xcode, such as MacRuby's Compile or
     # Embed.
-    # Uses the application name by default.
+    # Default: empty
     attr_accessor :build_target
-    def build_target
-      @build_target ||= name
-    end
   
     def target_bundle
       @target_bundle ||= Dir["#{build_products}/#{name}.*"].first

--- a/lib/choctop/appcast.rb
+++ b/lib/choctop/appcast.rb
@@ -4,7 +4,8 @@ module ChocTop
       if skip_xcode_build
         puts "Skipping build task..."
       else
-        sh "xcodebuild -configuration #{build_type} -target #{build_target} #{build_opts}"
+        build_target_args = "-target '#{build_target}'" if build_target
+        sh "xcodebuild -configuration #{build_type} #{build_target_args} #{build_opts}"
       end
     end
 


### PR DESCRIPTION
I've changed the call to `xcodebuild` to omit the `target` argument when no target is given rather than passing the app's name as the default target. By default, xcodebuild builds the first target listed in the project.
