### PR TITLE
Quote build type and build target

### DIFF
--- a/lib/choctop/appcast.rb
+++ b/lib/choctop/appcast.rb
@@ -4,7 +4,7 @@ module ChocTop
       if skip_xcode_build
         puts "Skipping build task..."
       else
-        sh "xcodebuild -configuration #{build_type} -target #{build_target} #{build_opts}"
+        sh "xcodebuild -configuration '#{build_type}' -target '#{build_target}' #{build_opts}"
       end
     end
 


### PR DESCRIPTION
When you have a build type or build target with spaces on the name, the xcodebuild command invocation fails.

This commit fixes that issue.
