### PR TITLE
Symlink problem

### DIFF
--- a/lib/choctop.rb
+++ b/lib/choctop.rb
@@ -33,6 +33,7 @@ module ChocTop
 
     # Name of the Info.plist file
     # Default: "Info.plist"
+    attr_accessor :info_plist_name
     def info_plist_name
       @info_plist_name ||= 'Info.plist'
     end

--- a/lib/choctop.rb
+++ b/lib/choctop.rb
@@ -44,8 +44,12 @@ module ChocTop
     attr_accessor :name
   
     # The version of the Cocoa application
-    # Default: info_plist['CFBundleVersion']
+    # Default: info_plist['CFBundleShortVersionString']
     attr_accessor :version
+
+    # The internal version of the Cocoa application
+    # Default: info_plist['CFBundleVersion']
+    attr_accessor :internal_version
   
     # The target name of the distributed DMG file
     # Default: #{name}.app
@@ -332,7 +336,8 @@ module ChocTop
       # Defaults
       @name ||= info_plist['CFBundleExecutable'] || File.basename(File.expand_path("."))
       @name = File.basename(File.expand_path(".")) if @name == '${EXECUTABLE_NAME}'
-      @version ||= info_plist['CFBundleVersion']
+      @version ||= info_plist['CFBundleShortVersionString']
+      @internal_version ||= info_plist['CFBundleVersion']
       @build_type = ENV['BUILD_TYPE'] || 'Release'
     
       if base_url

--- a/lib/choctop/appcast.rb
+++ b/lib/choctop/appcast.rb
@@ -34,7 +34,8 @@ module ChocTop
               xml.enclosure(:url => "#{base_url}/#{pkg_name}",
                             :length => "#{File.size(pkg)}",
                             :type => "application/dmg",
-                            :"sparkle:version" => version,
+                            :"sparkle:version" => internal_version,
+                            :"sparkle:shortVersionString" => version,
                             :"sparkle:dsaSignature" => dsa_signature)
             end
           end

--- a/lib/choctop/dmg.rb
+++ b/lib/choctop/dmg.rb
@@ -24,19 +24,17 @@ module ChocTop
       end
     end
 
-    # Two-phase copy: first to a tmp folder (to prevent recursion); then tmp folder to +dmg_src_folder+
     def copy_files
-      FileUtils.mkdir_p(tmp_dmg_src_folder)
-      files.each do |path, options|
+      FileUtils.rm_r(dmg_src_folder) if File.exists? dmg_src_folder
+      FileUtils.mkdir_p(dmg_src_folder)                            
+      
+      files.each do |path, options|                
         if options[:link]
           add_link_to_dmg_src_folder(path, options)
         else
           add_file_to_dmg_src_folder(path, options)
         end
-      end
-      FileUtils.rm_r(dmg_src_folder) if File.exists? dmg_src_folder
-      FileUtils.mkdir_p(dmg_src_folder)
-      Dir["#{tmp_dmg_src_folder}/*"].each { |f| FileUtils.cp_r(f, dmg_src_folder) }
+      end                        
     end
 
     def make_dmg
@@ -196,8 +194,8 @@ module ChocTop
     end
     
     def add_file_to_dmg_src_folder(path, options)
-      target = File.join(tmp_dmg_src_folder, options[:name])
-      sh ::Escape.shell_command(['cp', '-r', path, target])
+      target = File.join(dmg_src_folder, options[:name])
+      FileUtils.copy_entry(path, target)      
       if options[:exclude]
         exclude_list = options[:exclude].is_a?(Array) ? options[:exclude] : [options[:exclude].to_s]
         exclude_list.each { |exclude| sh ::Escape.shell_command(['rm', '-rf', File.join(target, exclude)]) }
@@ -206,8 +204,8 @@ module ChocTop
 
     def add_link_to_dmg_src_folder(path, options)
       plist_name   = options[:name].gsub(/\.webloc$/, '')
-      plist_target = File.join(tmp_dmg_src_folder, plist_name)
-      target       = File.join(tmp_dmg_src_folder, options[:name])
+      plist_target = File.join(dmg_src_folder, plist_name)
+      target       = File.join(dmg_src_folder, options[:name])
       sh ::Escape.shell_command(['defaults', 'write', plist_target, 'URL', options[:url]])
       sh ::Escape.shell_command(['plutil', '-convert', 'xml1', '-o', target, "#{plist_target}.plist"])
       sh ::Escape.shell_command(['rm', "#{plist_target}.plist"])
@@ -225,13 +223,6 @@ module ChocTop
         end
       end
       applescript
-    end
-    
-    def tmp_dmg_src_folder
-      @tmp_dmg_src_folder ||= begin
-        require 'tmpdir'
-        File.join(Dir.tmpdir, Time.now.to_i.to_s) # probably unique folder
-      end
     end
   end
 end

--- a/spec/fixtures/Info.plist
+++ b/spec/fixtures/Info.plist
@@ -18,7 +18,7 @@
 	<string>APPL</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
-	<key>CFBundleVersion</key>
+	<key>CFBundleShortVersion</key>
 	<string>1.0</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>


### PR DESCRIPTION
Currently if your target embeds frameworks, all symlinks inside those frameworks are converted into directories which results in duplicated content (easily can double or even triple the size of package). This patch ensures that symlinks are copied as-is to avoid duplications.
