### PR TITLE
Added rubigen dependency required in install_choctop bin

### DIFF
--- a/choctop.gemspec
+++ b/choctop.gemspec
@@ -50,6 +50,7 @@ All rake tasks:
       s.add_runtime_dependency(%q<awesome_print>, ["= 0.2.1"])
       s.add_runtime_dependency(%q<RedCloth>, ["= 4.2.3"])
       s.add_runtime_dependency(%q<escape>, ["= 0.0.4"])
+      s.add_runtime_dependency(%q<rubigen>, ["= 1.5.5"])
       s.add_development_dependency(%q<bundler>, [">= 0"])
       s.add_development_dependency(%q<rspec>, [">= 2.0.0.beta"])
       s.add_development_dependency(%q<cucumber>, ["= 0.8.3"])


### PR DESCRIPTION
I'm not super familiar with the project but this was an issue on clean install for me.

```
John-Benders-MacBook-Pro:osx nickel$ install_choctop --version
/Library/Ruby/Site/1.8/rubygems/custom_require.rb:36:in `gem_original_require': no such file to load -- rubigen (LoadError)
    from /Library/Ruby/Site/1.8/rubygems/custom_require.rb:36:in `require'
    from /Library/Ruby/Gems/1.8/gems/choctop-0.14.1/bin/install_choctop:4
    from /usr/bin/install_choctop:19:in `load'
    from /usr/bin/install_choctop:19

```

[edit] fix for unit tests in a separate pull request
