### PR TITLE
Fixed failing "unit" specs

### DIFF
--- a/spec/choctop_spec.rb
+++ b/spec/choctop_spec.rb
@@ -105,6 +105,7 @@ describe ChocTop::Configuration do
         FileUtils.chdir(@my_project_path) do
           @choctop = ChocTop::Configuration.new do |s|
             s.defaults :textmate
+            s.add_file "README.txt", :position => [0,0]
           end
           @choctop.prepare_files
         end


### PR DESCRIPTION
I saw two failures for the "unit" specs along with a host of cucumber test failures. This does not address the cucumber failures.
